### PR TITLE
Latex & link fixes

### DIFF
--- a/src/installation.md
+++ b/src/installation.md
@@ -1,79 +1,79 @@
 # Installation
 
-Bittensor installation requires two installations: Bittensor and Subtensor. Bittensor is the python-based machine learning layer, whereas Subtensor is the rust-based blockchain consensus layer. They must run concurrently for each model. 
+Bittensor installation requires two installations: Bittensor and Subtensor. Bittensor is the python-based machine learning layer, whereas Subtensor is the rust-based blockchain consensus layer. They must run concurrently for each model.
 
 - **NOTE**
-    
+
     It is highly recommend to **install Bittensor first** and then install Subtensor.
-    
+
 
 ## Installing Bittensor
 
-There are three ways to install Bittensor. 
+There are three ways to install Bittensor.
 
 1. Using the installer script. This is the easiest method and is recommended if you are new. Simply paste the following into your terminal.
-    
+
     ```bash
     /bin/bash -c "$(curl -fsSL [https://raw.githubusercontent.com/opentensor/bittensor/master/scripts/install.sh](https://raw.githubusercontent.com/opentensor/bittensor/master/scripts/install.sh))
     ```
-    
+
 2. Using pip.
-    
+
     ```bash
     pip3 install bittensor
     ```
-    
+
 3. From source.
-    
+
     ```bash
     git clone [https://github.com/opentensor/bittensor.git](https://github.com/opentensor/bittensor.git)
     $ python3 -m pip install -e bittensor/
     ```
-    
 
-Once installed, you can verify your installation by running the [Bittensor Command Line Interface](https://www.notion.so/Bittensor-Command-Line-Interface-btcli-f2f87e792037423493bfaacd5e3fea4d) (CLI) with `btcli --help`. The Bittensor CLI is the primary tool for interfacing with the Bittensor network. 
+
+Once installed, you can verify your installation by running the [Bittensor Command Line Interface](/documentation/btcli) (CLI) with `btcli --help`. The Bittensor CLI is the primary tool for interfacing with the Bittensor network.
 
 ## Run Subtensor on Docker
 
 Subtensor can be run straight through the included Docker container. This is the fastest and most reliable method to run Subtensor as Docker takes care of all required setup.
 
 1. Clone the Subtensor repository.
-    
+
     ```bash
     git clone https://github.com/opentensor/subtensor.git ~/.bittensor
     ```
-    
+
     This will clone the Subtensor repository to `~/.bittensor`.
-    
-2. Run Subtensor in a Docker container. 
-    
+
+2. Run Subtensor in a Docker container.
+
     ```bash
     cd ~/.bittensor/subtensor && docker-compose up -d
     ```
-    
-    This will run the blockchain in a Docker container, and will take about 5 minutes to fully synchronize with the rest of the network before it is useable. 
-    
+
+    This will run the blockchain in a Docker container, and will take about 5 minutes to fully synchronize with the rest of the network before it is useable.
+
 
 ## Run Subtensor Natively
 
-You can also run Subtensor natively, this has a few advantages as it will run faster than a Docker container and allows you to use specific flags. 
+You can also run Subtensor natively, this has a few advantages as it will run faster than a Docker container and allows you to use specific flags.
 
 1. [Install Rust locally.](https://www.rust-lang.org/tools/install)
-    
+
     ```bash
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ```
-    
+
 2. Install the correct nightly toolchain.
-    
+
     ```bash
     cd ~/.bittensor/subtensor && ./scripts/init.sh
     ```
-    
-3. Build and compile Subtensor. This process will take a long time. 
-    
+
+3. Build and compile Subtensor. This process will take a long time.
+
     ```bash
     cargo build --release --features runtime-benchmarks
     ```
-    
+
 4. Simply copy/paste the line to run Subtensor from `docker-compose.yml`

--- a/src/taonomics.md
+++ b/src/taonomics.md
@@ -6,34 +6,34 @@ Tao is the token for Bittensor and gatekeeps access, representing bandwidth to t
 
 
 
-**Emission Split**: Each subnetwork \\(h\\) receives a set percentage \\(E_h\\) of total emission \\(E=\sum_h E_h\\).
+**Emission Split**: Each subnetwork \\[h\\] receives a set percentage \\[E_h\\] of total emission \\[E=\sum_h E_h\\].
 Servers and Validators evenly split emissions per block, with the most emissions issued to the best-performing Servers and largest Validators.
 
-**Weights**: Each Validator \\(i\\) evaluates the relative utility of each Server \\(j\\), and sets weights \\(\sum_jW_{ij}=1\\) on-chain, signed with the Validator hotkey. A relatively high weight indicates relatively high Server utility.
+**Weights**: Each Validator \\[i\\] evaluates the relative utility of each Server \\[j\\], and sets weights \\[\sum_jW_{ij}=1\\] on-chain, signed with the Validator hotkey. A relatively high weight indicates relatively high Server utility.
 
-**Prerank**: Server rank \\(R_j\\) is the sum of weighted stake set on \\(j\\), before consensus. A high rank indicates that majority stake agrees on relatively high utility of a Server.
+**Prerank**: Server rank \\[R_j\\] is the sum of weighted stake set on \\[j\\], before consensus. A high rank indicates that majority stake agrees on relatively high utility of a Server.
 \\[P_j = \sum_i S_i \cdot W_{ij}\\]
 
-**Consensus**: On-chain consensus then calculates stake-based median weight \\(C_j\\) for each Server \\(j\\), which is the maximum weight supported by at least \\(\kappa\\)-majority stake, so that stake sum (as ratio of total active stake) of active Validators setting at least consensus weight is \\(\kappa\\) (typically \\(\kappa=0.5\\)).
+**Consensus**: On-chain consensus then calculates stake-based median weight \\[C_j\\] for each Server \\[j\\], which is the maximum weight supported by at least \\[\kappa\\]-majority stake, so that stake sum (as ratio of total active stake) of active Validators setting at least consensus weight is \\[\kappa\\] (typically \\[\kappa=0.5\\]).
 \\[C_j = \max w:\quad \kappa \le \sum_i S_i \cdot \left( w \le W_{ij} \right)\\]
 <img src="images/consensus_plots.png">
 
-**Validator Trust**: Clip weights above consensus to penalize overweighting, the sum of consensus-clipped weight is then Validator trust \\(V_i\\), which is the weighting power remaining after consensus (initially starts with 100% power). High Validator trust means it is typically setting weights in agreement with majority stake.
+**Validator Trust**: Clip weights above consensus to penalize overweighting, the sum of consensus-clipped weight is then Validator trust \\[V_i\\], which is the weighting power remaining after consensus (initially starts with 100% power). High Validator trust means it is typically setting weights in agreement with majority stake.
 \\[V_i = \sum_j\min\left( W_{ij}, C_j \right)\\]
 
-**Server Incentive**: Server rank \\(R_j\\) is the sum of weighted stake set on \\(j\\), which is also the Server incentive ratio \\(I_j\\). Better performing Servers get relatively higher rank and incentive.
+**Server Incentive**: Server rank \\[R_j\\] is the sum of weighted stake set on \\[j\\], which is also the Server incentive ratio \\[I_j\\]. Better performing Servers get relatively higher rank and incentive.
 \\[I_j = R_j = \sum_i S_i \cdot \min\left( W_{ij}, C_j \right)\\]
 
-**Server Trust**: The ratio of Server \\(j\\) rank \\(R_j\\) to its prerank \\(P_j\\) is the trust \\(T_j\\) in the initial weights set on the Server. High Server trust indicates that mostly trusted Validators set weights on it.
+**Server Trust**: The ratio of Server \\[j\\] rank \\[R_j\\] to its prerank \\[P_j\\] is the trust \\[T_j\\] in the initial weights set on the Server. High Server trust indicates that mostly trusted Validators set weights on it.
 \\[T_j = \frac{R_j}{P_j}\\]
 
-**Validator Bonds**: Validators accumulate bonded relationships \\(B_{ij}\\) in the Servers they rank, adding \\(\Delta B_{ij} = S_i \cdot \min \left( W_{ij}, C_j \right)\\) (normalized across Validators) via exponential moving average at each epoch \\(t\\) (typically \\(\alpha=0.1\\)).
+**Validator Bonds**: Validators accumulate bonded relationships \\[B_{ij}\\] in the Servers they rank, adding \\[\Delta B_{ij} = S_i \cdot \min \left( W_{ij}, C_j \right)\\] (normalized across Validators) via exponential moving average at each epoch \\[t\\] (typically \\[\alpha=0.1\\]).
 \\[B_{ij}^{(t)} = \alpha \Delta B_{ij} + (1-\alpha) B_{ij}^{(t-1)} \\]
 
-**Validator Reward**: Validators receive a portion (typically 50%) of the incentive of bonded Servers as reward \\(D_i\\) for setting weights in consensus.
+**Validator Reward**: Validators receive a portion (typically 50%) of the incentive of bonded Servers as reward \\[D_i\\] for setting weights in consensus.
 \\[D_i = \sum_j B_{ij} \cdot I_j\\]
 
-**Emission**: Neurons can simultaneously act as Server and Validator, and generally its emission comprises Server incentive \\(I_i/2\\) and Validator reward \\(D_i/2\\), since it is granting half incentive to its bondholders and gains half incentive from those Servers it is bonded to.
+**Emission**: Neurons can simultaneously act as Server and Validator, and generally its emission comprises Server incentive \\[I_i/2\\] and Validator reward \\[D_i/2\\], since it is granting half incentive to its bondholders and gains half incentive from those Servers it is bonded to.
 \\[E_i = \left(I_i + D_i\right)\left/2\right.\\]
 
 **Consensus Guarantees**: Unfairly high self-weight set by minority-stake cabals gets clipped at consensus and removes significant voting power. Optimal cabal attacks aim to set self-weights that maximize honest self-weight (utility) required for retaining majority stake. Subtensor implements on-chain consensus and verifies its guarantees via integration tests. It also maps guarantees for given weight standard deviations by simulating large networks and optimizing cabal attacks.

--- a/src/validator.md
+++ b/src/validator.md
@@ -1,8 +1,8 @@
 # Run a Validator
 
-Validators on the Bittensor network ensure that Neurons are honest and that the best Neurons are rewarded according to their performance. 
+Validators on the Bittensor network ensure that Neurons are honest and that the best Neurons are rewarded according to their performance.
 
-It is important to distinguish a Bittensor validator from a traditional Blockchain validator. Bittensor verifiers contain a [Mixture-of-Experts](https://arxiv.org/abs/1701.06538) gating layer as well as a reward model to ensure that the right [Neuron](https://www.notion.so/Run-a-Neuron-78088891b9914b7f9ec510d41d3ebda6) gets rewarded accordingly. However, they are not involved in verifying transactions and enforcing the consensus mechanism. This is handled by the traditional Blockchain validator that runs Subtensor.
+It is important to distinguish a Bittensor validator from a traditional Blockchain validator. Bittensor verifiers contain a [Mixture-of-Experts](https://arxiv.org/abs/1701.06538) gating layer as well as a reward model to ensure that the right [Neuron](/documentation/neuron) gets rewarded accordingly. However, they are not involved in verifying transactions and enforcing the consensus mechanism. This is handled by the traditional Blockchain validator that runs Subtensor.
 
 Similarly to the Model Neurons, the Validator Neuron is located under `neurons` [on the Bittensor repository](https://github.com/opentensor/bittensor/blob/text_prompting/neurons/text/prompting/validators/core/neuron.py).  You can run the validator using the following, where `--netuid 1` specifies the validator to be run on Subnetwork 1.
 


### PR DESCRIPTION
This patch changes non-valid inline Latex to one that compiles easily and looks pretty :)

| before | after |
|:---:|:---:|
| ![image](https://github.com/opentensor/docs/assets/96201196/7728abdb-30d3-414e-8b02-2f652910b99b) | ![image](https://github.com/opentensor/docs/assets/96201196/f42fdfba-fcd6-4239-95ec-c3c4f687f245) |