### PR TITLE
Added new installation instructions for mac M1 processors

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -32,3 +32,19 @@ Once installed, you can verify installation using the [Bittensor Command Line In
 import bittensor as bt
 print( bt.__version__ )
 ```
+
+### 04 Installation on Apple M chip
+There are quite a few Python libraries that are not yet compatible with Apple M chipset architecture. The best way to use Bittensor on this hardware is through Conda and Miniforge. The Opentensor team has created a Conda environment that makes installing Bittensor on these systems very easy. Simply download the YAML file [here](https://conda.io/projects/conda/en/latest/user-guide/install/macos.html). 
+
+> NOTE: This tutorial assumes you have installed conda on mac, if you have not done so already you can install it from [here](https://conda.io/projects/conda/en/latest/user-guide/install/macos.html).
+
+1. Create the conda environment from the `apple_m1_environment.yml` file here:
+    ```bash
+    conda env create -f apple_m1_environment.yml
+    ```
+
+2. Activate the new environment: `conda activate bittensor`.
+3. Verify that the new environment was installed correctly:
+   ```bash
+   conda env list
+   ```

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -34,7 +34,7 @@ print( bt.__version__ )
 ```
 
 ### 04 Installation on Apple M chip
-There are quite a few Python libraries that are not yet compatible with Apple M chipset architecture. The best way to use Bittensor on this hardware is through Conda and Miniforge. The Opentensor team has created a Conda environment that makes installing Bittensor on these systems very easy. Simply download the YAML file [here](https://conda.io/projects/conda/en/latest/user-guide/install/macos.html). 
+There are quite a few Python libraries that are not yet compatible with Apple M chipset architecture. The best way to use Bittensor on this hardware is through Conda and Miniforge. The Opentensor team has created a Conda environment that makes installing Bittensor on these systems very easy. Simply download the YAML file [here](https://github.com/opentensor/bittensor/blob/master/scripts/environments/apple_m1_environment.yml). 
 
 > NOTE: This tutorial assumes you have installed conda on mac, if you have not done so already you can install it from [here](https://conda.io/projects/conda/en/latest/user-guide/install/macos.html).
 


### PR DESCRIPTION
This PR adds installation instructions for M1 processors. 

~Presently blocked on https://github.com/opentensor/bittensor/pull/1386, that PR needs to be merged and this one updated before being merged.~

