### PR TITLE
edit: removed openai import from langchain section

### DIFF
--- a/clients/clients.md
+++ b/clients/clients.md
@@ -49,9 +49,7 @@ The BittensorLLM object can be integrated with langchain.
 
 ```python numbered dark removed=2,4 added=1,3
 import bittensor as bt
-from langchain import openai
 llm = bt.BittensorLLM()
-ll = openai.llm( api_key = **** )
 llm( 'prompt me' )
 ```
 


### PR DESCRIPTION

![image](https://github.com/opentensor/docs/assets/65109440/915c0d76-f390-4fbd-a40d-dfaa3ccc005b)

currently we can't have strikethroughs within code segments as everything rendered within the code blocks gets rendered as code (in this case python code) and not as markdown see [GitHub issue](https://github.com/adam-p/markdown-here/issues/291)

Alternatively, we can have the strikethrough (if we want to show a comparison) within the text sections in the docs 