### PR TITLE
add wallet update mention and example

### DIFF
--- a/getting-started/wallets.md
+++ b/getting-started/wallets.md
@@ -268,15 +268,24 @@ For example:
 ```bash dark
 btcli wallet update
 >> Do you want to update all legacy wallets? [y/n]: n
->> Enter wallet name (default): default
+>> Enter wallet name (default): my_coldkey
 >> 
->> =====  wallet(default, default, ~/.bittensor/wallets/)  =====
+>> =====  wallet(my_coldkey, default, ~/.bittensor/wallets/)  =====
 >> You may update the keyfile to improve the security for storing your keys.
 >> While the key and the password stays the same, it would require providing your password once.
 >> 🔑Keyfile (Ansible Vault encrypted, ~/.bittensor/wallets/default/coldkey)>
 >> 
 >> Update keyfile? [y/n]: y
->> =====  wallet(vali_cold, default, ~/.bittensor/wallets/)  =====
+>> =====  wallet(my_coldkey, default, ~/.bittensor/wallets/)  =====
+>>
+>> Update keyfile? [y/n]: y
+>>
+>> Please make sure you have the mnemonic stored in case an error occurs during the transfer.
+>>
+>> Have you stored the mnemonic? [y/n]: y
+>>
+>> Enter password to update keyfile:
+>> ********
 >>
 >> ✅ Keyfile is updated. 
 >> 🔑 Keyfile (NaCl encrypted, ~/.bittensor/wallets/default/coldkey)>

--- a/getting-started/wallets.md
+++ b/getting-started/wallets.md
@@ -260,3 +260,24 @@ Creates a coldkey from a suri string. Optionally encrypts and overwrites existin
 
 
 
+#### Update wallet
+
+It is imperative to update any legacy wallets to the new NaCL format for security. You may accomplish this with the `btcli` using the `wallet update` subcommands.
+
+For example:
+```bash dark
+btcli wallet update
+>> Do you want to update all legacy wallets? [y/n]: n
+>> Enter wallet name (default): default
+>> 
+>> =====  wallet(default, default, ~/.bittensor/wallets/)  =====
+>> You may update the keyfile to improve the security for storing your keys.
+>> While the key and the password stays the same, it would require providing your password once.
+>> 🔑Keyfile (Ansible Vault encrypted, ~/.bittensor/wallets/default/coldkey)>
+>> 
+>> Update keyfile? [y/n]: y
+>> =====  wallet(vali_cold, default, ~/.bittensor/wallets/)  =====
+>>
+>> ✅ Keyfile is updated. 
+>> 🔑 Keyfile (NaCl encrypted, ~/.bittensor/wallets/default/coldkey)>
+```


### PR DESCRIPTION
Gives an example for updating legacy wallets in the docs, urging people to convert.

Will mention this in an announcement to compel users who have not already updated yet.